### PR TITLE
Much more effective refresh & Routingtable add contact will never add itself now.

### DIFF
--- a/src/kademlia/routingtable.go
+++ b/src/kademlia/routingtable.go
@@ -28,6 +28,9 @@ func NewRoutingTable(me Contact) *RoutingTable {
 
 // AddContact add a new contact to the correct Bucket
 func (routingTable *RoutingTable) AddContact(contact Contact) {
+	if contact.ID.Equals(routingTable.me.ID) {
+		return
+	}
 	bucketIndex := routingTable.getBucketIndex(contact.ID)
 	bucket := routingTable.buckets[bucketIndex]
 	bucket.AddContact(contact)


### PR DESCRIPTION
Much more effective refresh & Routingtable add contact will never add itself now.

It simply ignores to ask for find_node on buckets if the buckets are empty. 